### PR TITLE
Update README to add sprint 1 ppt link

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,7 @@ Release 4 (Deadline: Apr 6, Demo4: Apr 9)
 Release 5 (Deadline: end of semester)
 - Complete documentation and make sure every part is functional, stable, and verified
 - Final video
+
+##7. Sprint demos and presentations
+
+- [Sprint 1 presentation](https://northeastern-my.sharepoint.com/:p:/r/personal/mahapatra_an_northeastern_edu/_layouts/15/Doc.aspx?sourcedoc=%7B106CE9C6-8DD2-4002-A918-8750DDDD8A0F%7D&file=Enahanced%20CI_CD%20pipeline%20-%20Sprint%201.pptx&wdOrigin=OFFICECOM-WEB.START.REC&ct=1614736027095&action=edit&mobileredirect=true)


### PR DESCRIPTION
Added "Sprint 1 presentation" link in README file 

(https://northeastern-my.sharepoint.com/:p:/r/personal/mahapatra_an_northeastern_edu/_layouts/15/Doc.aspx?sourcedoc=%7B106CE9C6-8DD2-4002-A918-8750DDDD8A0F%7D&file=Enahanced%20CI_CD%20pipeline%20-%20Sprint%201.pptx&wdOrigin=OFFICECOM-WEB.START.REC&ct=1614736027095&action=edit&mobileredirect=true)